### PR TITLE
Make relative imports changes for Python 3

### DIFF
--- a/tests/main.sh
+++ b/tests/main.sh
@@ -9,8 +9,8 @@ else
 fi
 
 modules="
-    test-mlmmj.py
-    test-cleanup.py
+    test_mlmmj.py
+    test_cleanup.py
 "
 
 # py.test command line arguments

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,4 +1,4 @@
-from utils import remove_ml
+from .utils import remove_ml
 
 
 def test_cleanup():

--- a/tests/test_mlmmj.py
+++ b/tests/test_mlmmj.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 from . import get, put, debug
-from utils import create_ml, remove_ml
-import data
+from .utils import create_ml, remove_ml
+from . import data
 
 
 def test_invalid_domain():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from . import get, post, delete, debug
-import data
+from . import data
 
 
 def remove_ml(archive=False):


### PR DESCRIPTION
Various changes so we can just type __pytest__ to run the test suite on Python 3.

__test-xyz.py__ -> __test_xyz.py__ for https://docs.pytest.org/en/latest/goodpractices.html#test-discovery